### PR TITLE
Delete não apaga, apenas inativa user

### DIFF
--- a/src/main/kotlin/com/picPaySimplificado/controller/CustomerController.kt
+++ b/src/main/kotlin/com/picPaySimplificado/controller/CustomerController.kt
@@ -5,6 +5,7 @@ import com.picPaySimplificado.model.CustomerModel
 import org.springframework.web.bind.annotation.*
 import com.picPaySimplificado.controller.request.PostCustomerRequest
 import com.picPaySimplificado.controller.request.PutCustomerRequest
+import com.picPaySimplificado.enums.CustomerStatus
 import com.picPaySimplificado.service.CustomerService
 import jakarta.transaction.Transactional
 import jakarta.validation.Valid
@@ -51,7 +52,8 @@ class CustomerController(
             registroGoverno = putCustomerRequest.registroGoverno,
             email = putCustomerRequest.email,
             senha = putCustomerRequest.senha,
-            saldo = putCustomerRequest.saldo
+            saldo = putCustomerRequest.saldo,
+            status = CustomerStatus.ATIVO
 
         )
         service.update(customer)

--- a/src/main/kotlin/com/picPaySimplificado/enums/CustomerStatus.kt
+++ b/src/main/kotlin/com/picPaySimplificado/enums/CustomerStatus.kt
@@ -1,0 +1,6 @@
+package com.picPaySimplificado.enums
+
+enum class CustomerStatus {
+    ATIVO,
+    INATIVO
+}

--- a/src/main/kotlin/com/picPaySimplificado/extensions/ConverterExtensionFunction.kt
+++ b/src/main/kotlin/com/picPaySimplificado/extensions/ConverterExtensionFunction.kt
@@ -5,6 +5,7 @@ import com.picPaySimplificado.model.TransactionModel
 import com.picPaySimplificado.controller.request.PostCustomerRequest
 import com.picPaySimplificado.controller.request.PutCustomerRequest
 import com.picPaySimplificado.controller.request.TransactionRequest
+import com.picPaySimplificado.enums.CustomerStatus
 
 fun PostCustomerRequest.toCustomerModel(): CustomerModel {
     return CustomerModel(
@@ -19,10 +20,11 @@ fun PostCustomerRequest.toCustomerModel(): CustomerModel {
 
         saldo = this.saldo,
 
+        status = CustomerStatus.ATIVO
         )
 }
 
-fun PutCustomerRequest.toCustomerModel(customer: PutCustomerRequest): CustomerModel {
+fun PutCustomerRequest.toCustomerModel(previousValue: CustomerModel): CustomerModel {
     return CustomerModel(
 
         nomeCompleto = this.nomeCompleto,
@@ -34,6 +36,8 @@ fun PutCustomerRequest.toCustomerModel(customer: PutCustomerRequest): CustomerMo
         senha = this.senha,
 
         saldo = this.saldo,
+
+        status = previousValue.status
 
         )
 }

--- a/src/main/kotlin/com/picPaySimplificado/model/CustomerModel.kt
+++ b/src/main/kotlin/com/picPaySimplificado/model/CustomerModel.kt
@@ -1,10 +1,7 @@
 package com.picPaySimplificado.model
 
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
+import com.picPaySimplificado.enums.CustomerStatus
+import jakarta.persistence.*
 
 @Entity(name = "customer")
 data class CustomerModel(
@@ -19,7 +16,10 @@ data class CustomerModel(
 
     @Column var senha: String,
 
-    @Column var saldo: Float
+    @Column var saldo: Float,
+
+
+    @Column @Enumerated(EnumType.STRING) var status: CustomerStatus
 ) {
 
     fun ePJ() = this.registroGoverno.length == 14

--- a/src/main/kotlin/com/picPaySimplificado/service/CustomerService.kt
+++ b/src/main/kotlin/com/picPaySimplificado/service/CustomerService.kt
@@ -1,6 +1,7 @@
 package com.picPaySimplificado.service
 
 
+import com.picPaySimplificado.enums.CustomerStatus
 import com.picPaySimplificado.enums.Errors
 import com.picPaySimplificado.exception.BadRequestException
 import com.picPaySimplificado.model.CustomerModel
@@ -29,10 +30,10 @@ class CustomerService(private val repository: CustomerRepository) {
 
     fun findCustomer(id: Int): CustomerModel {
         return repository.findById(id).orElseThrow {
-                com.picPaySimplificado.exception.NotFoundException(
-                    Errors.CO001.message.format(id), Errors.CO001.code
-                )
-            }
+            com.picPaySimplificado.exception.NotFoundException(
+                Errors.CO001.message.format(id), Errors.CO001.code
+            )
+        }
     }
 
 
@@ -42,6 +43,7 @@ class CustomerService(private val repository: CustomerRepository) {
                 Errors.CO002.message.format(customer.id), Errors.CO002.code
             )
         }
+        customer.status = repository.findById(customer.id!!).get().status
         repository.save(customer)
     }
 
@@ -51,7 +53,10 @@ class CustomerService(private val repository: CustomerRepository) {
                 Errors.CO003.message.format(id), Errors.CO003.code
             )
         }
-        repository.deleteById(id)
+        val customer = repository.findById(id).get()
+
+        customer.status = CustomerStatus.INATIVO
+        repository.save(customer)
     }
 
     fun emailAvailable(email: String): Boolean {

--- a/src/main/resources/db/migration/V2__create-table-customer.sql
+++ b/src/main/resources/db/migration/V2__create-table-customer.sql
@@ -1,0 +1,27 @@
+CREATE SCHEMA testepicpay;
+
+CREATE TABLE customer
+(
+    id              INT PRIMARY KEY AUTO_INCREMENT,
+    nomeCompleto    VARCHAR(256)        NOT NULL,
+    registroGoverno VARCHAR(14) UNIQUE  NOT NULL,
+    email           VARCHAR(256) UNIQUE NOT NULL,
+    senha           VARCHAR(256)        NOT NULL,
+    saldo           FLOAT               NOT NULL,
+    status          VARCHAR(8)          NOT NULL
+);
+
+CREATE TABLE transaction_history
+(
+    id               INT PRIMARY KEY AUTO_INCREMENT,
+    envia            INT   NOT NULL,
+    recebe           INT   NOT NULL,
+    valor            FLOAT NOT NULL,
+    transaction_date DATE
+);
+
+ALTER TABLE transaction_history
+    ADD CONSTRAINT FK_transaction_history_2
+        foreign key (envia, recebe) references customer (id, id);
+
+/*

--- a/src/test/kotlin/com/picPaySimplificado/service/CustomerServiceTest.kt
+++ b/src/test/kotlin/com/picPaySimplificado/service/CustomerServiceTest.kt
@@ -1,5 +1,6 @@
 package com.picPaySimplificado.service
 
+import com.picPaySimplificado.enums.CustomerStatus
 import com.picPaySimplificado.exception.BadRequestException
 import com.picPaySimplificado.exception.NotFoundException
 import com.picPaySimplificado.model.CustomerModel
@@ -9,6 +10,7 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
+import jakarta.persistence.EnumType
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -41,21 +43,34 @@ class CustomerServiceTest() {
     }
 
     @Test
-    fun `should create customers`() {
+    fun `should create customers cpf`() {
         val id = Random().nextInt()
         val fakeCustomer = buildCustomer(id = id)
-        val fakeMerchant = buildCustomer(id = id + 123)
 
         //given
         every { repository.save(fakeCustomer) } returns fakeCustomer
-        every { repository.save(fakeMerchant) } returns fakeMerchant
         //when
         customerService.create(fakeCustomer)
-        customerService.create(fakeMerchant)
+
         //then
         verify(exactly = 1) { repository.save(fakeCustomer) }
-        verify(exactly = 1) { repository.save(fakeMerchant) }
+
     }
+
+    @Test
+    fun `should create customers cnpj`() {
+        val id = Random().nextInt()
+        val fakeMerchant = buildCustomer(id = id + 123)
+
+        //given
+        every { repository.save(fakeMerchant) } returns fakeMerchant
+        //when
+        customerService.create(fakeMerchant)
+        //then
+        verify(exactly = 1) { repository.save(fakeMerchant) }
+
+    }
+
 
     @Test
     fun `should return the specific exception create customers`() {
@@ -66,7 +81,7 @@ class CustomerServiceTest() {
         //given
         every { repository.save(fakeCustomer) } returns fakeCustomer
         //when
-        val error = assertThrows<BadRequestException>{ customerService.create(fakeCustomer) }
+        val error = assertThrows<BadRequestException> { customerService.create(fakeCustomer) }
         //then
 
         assertEquals("Insira um CPF ou um CNPJ", error.message)
@@ -109,12 +124,14 @@ class CustomerServiceTest() {
 
         //given
         every { repository.existsById(id) } returns true
+        every { repository.findById(id).get() } returns fakeCustomer
         every { repository.save(fakeCustomer) } returns fakeCustomer
 
         //when
         customerService.update(fakeCustomer)
         //then
         verify(exactly = 1) { repository.existsById(id) }
+        verify(exactly = 1) { repository.findById(id) }
         verify(exactly = 1) { repository.save(fakeCustomer) }
 
     }
@@ -167,13 +184,15 @@ class CustomerServiceTest() {
         registroGoverno: String = (1..11).joinToString("") { (0..9).random().toString() },
         email: String = "${UUID.randomUUID()}@email.com",
         senha: String = "password",
-        saldo: Float = 500.0F
-    ) = CustomerModel(
+        saldo: Float = 500.0F,
+        status: CustomerStatus = CustomerStatus.ATIVO
+    ): CustomerModel = CustomerModel(
         id = id,
         nomeCompleto = nomeCompleto,
         registroGoverno = registroGoverno,
         email = email,
         senha = senha,
-        saldo = saldo
+        saldo = saldo,
+        status = status
     )
 }


### PR DESCRIPTION
Criação do migration v2 - Adicionando status na tabela customer
Criado CustomerStatus
Adicionado atributo status que recebe um Enum com valores ativo/inativo
Delete agora não apaga, só inativa o usuario
create repartido em 3 testes separados (antes era 1 positivo e 1 negativo)
Ajuste em update para evitar que customer inativo seja ativado novamente

Atualizações futuras:
O user deve estar Ativo para que possa efetuar transação
Finalizando testes na camada Customer