### PR TITLE
Adição do TO-006

### DIFF
--- a/src/main/kotlin/com/picPaySimplificado/controller/request/PostCustomerRequest.kt
+++ b/src/main/kotlin/com/picPaySimplificado/controller/request/PostCustomerRequest.kt
@@ -5,6 +5,8 @@ import com.picPaySimplificado.validation.registroGovernoValidation.RegistroGover
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
+import org.hibernate.validator.constraints.br.CNPJ
+import org.hibernate.validator.constraints.br.CPF
 
 data class PostCustomerRequest(
 
@@ -13,9 +15,12 @@ data class PostCustomerRequest(
 
     @field:NotEmpty(message = "RegistroGoverno não pode ser nulo")
     @RegistroGovernoAvailable
+    @CPF(message = "CPF invalido")
+    @CNPJ(message = "CNPJ invalido")
     var registroGoverno: String,
 
-    @field:Email(message = "E-mail invalido") @field:NotEmpty( message = "E-mail não pode ser nulo")
+    @field:Email(message = "E-mail invalido")
+    @field:NotEmpty( message = "E-mail não pode ser nulo")
     @EmailAvailable
     var email: String,
 

--- a/src/main/kotlin/com/picPaySimplificado/enums/Errors.kt
+++ b/src/main/kotlin/com/picPaySimplificado/enums/Errors.kt
@@ -12,7 +12,8 @@ enum class Errors(val code: String, val message: String) {
     //Transaction
     TO001("TO-001", "Transação [%s] não existe"),
     TO002("TO-002", "Customer [%s] não é cliente."),
-    TO003("TO-003", "Customer [%s] não existe"),
-    TO004("TO-004", "Saldo insuficiente para efetuar esta operação"),
-    TO005("TO-005", "Impossivel prosseguir com a operação. Customer [%s] está inativo ")
+    TO003("TO-003", "Customer [%s] não existe."),
+    TO004("TO-004", "Saldo insuficiente para efetuar esta operação."),
+    TO005("TO-005", "Impossivel prosseguir com a operação. Customer [%s] está inativo."),
+    TO006("TO-006", "O id que envia é o mesmo que está recebendo.")
 }

--- a/src/main/kotlin/com/picPaySimplificado/service/TransactionService.kt
+++ b/src/main/kotlin/com/picPaySimplificado/service/TransactionService.kt
@@ -25,7 +25,7 @@ class TransactionService(
     fun transference(transaction: TransactionModel) {
 
         val getSenderData = customerService.senderValidate(transaction)
-        val getRecipientData = customerService.recipientValidate(transaction)
+        val getRecipientData = customerService.recipientValidate(transaction, getSenderData)
 
         customerService.checkBalance(transaction.valor, getSenderData.saldo)
 

--- a/src/test/kotlin/com/picPaySimplificado/service/TransactionServiceTest.kt
+++ b/src/test/kotlin/com/picPaySimplificado/service/TransactionServiceTest.kt
@@ -101,7 +101,7 @@ class TransactionServiceTest {
         every { customerService.senderValidate(transaction) } returns sender
 
         //recipientValidate
-        every { customerService.recipientValidate(transaction) } returns recipient
+        every { customerService.recipientValidate(transaction, sender) } returns recipient
 
         //checkBalance
         every { customerService.checkBalance(transaction.valor, sender.saldo) } returns true
@@ -121,7 +121,7 @@ class TransactionServiceTest {
         assertEquals(450.0F, getSenderData.saldo)
         assertEquals(550.0F, getRecipientData.saldo)
         verify(exactly = 1) { customerService.senderValidate(transaction) }
-        verify(exactly = 1) { customerService.recipientValidate(transaction) }
+        verify(exactly = 1) { customerService.recipientValidate(transaction, sender) }
         verify(exactly = 1) { repository.save(any()) }
         verify(exactly = 1) { postConfirmationTransactionByEmail.sendConfirmationForEmailApi(transaction) }
         verify(exactly = 1) { customerRepository.save(getSenderData) }


### PR DESCRIPTION
Alterações feitas

Adicionado:
trim para evitar entrada vazia
Nova validação para verificar se o id que envia é o mesmo que recebe
Erro TO-006 para tratar a nova validação
@CPF e @CNPJ para validação do PostCustomerRequest

Ajustado:
Testes quebrados por conta da alteração

Removido:
.get() desnecessarios