### PR TITLE
Ajustes nos testes e na validação

### DIFF
--- a/src/main/kotlin/com/picPaySimplificado/controller/request/PostCustomerRequest.kt
+++ b/src/main/kotlin/com/picPaySimplificado/controller/request/PostCustomerRequest.kt
@@ -15,8 +15,6 @@ data class PostCustomerRequest(
 
     @field:NotEmpty(message = "RegistroGoverno não pode ser nulo")
     @RegistroGovernoAvailable
-    @CPF(message = "CPF invalido")
-    @CNPJ(message = "CNPJ invalido")
     var registroGoverno: String,
 
     @field:Email(message = "E-mail invalido")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 server.port=3001
 
 spring.jpa.hibernate.ddl-auto=update
+#spring.datasource.url=jdbc:mysql://localhost:3306/testepicpay?createDatabaseIfNotExist=true
 spring.datasource.url=jdbc:mysql://mysql57:3306/testepicpay?createDatabaseIfNotExist=true
 spring.datasource.username=root
 spring.datasource.password=Password123#@!

--- a/src/test/kotlin/com/picPaySimplificado/service/CustomerServiceTest.kt
+++ b/src/test/kotlin/com/picPaySimplificado/service/CustomerServiceTest.kt
@@ -265,7 +265,7 @@ class CustomerServiceTest {
 
         val error = assertThrows<BadRequestException> { customerService.senderValidate(transaction) }
 
-        assertEquals("Customer [${id}] não existe", error.message)
+        assertEquals("Customer [${id}] não existe.", error.message)
         assertEquals("TO-003", error.errorCode)
         verify(exactly = 1) { repository.existsById(id) }
     }
@@ -281,7 +281,7 @@ class CustomerServiceTest {
 
         val error = assertThrows<BadRequestException> { customerService.senderValidate(transaction) }
 
-        assertEquals("Impossivel prosseguir com a operação. Customer [${id}] está inativo ", error.message)
+        assertEquals("Impossivel prosseguir com a operação. Customer [${id}] está inativo.", error.message)
         assertEquals("TO-005", error.errorCode)
         verify(exactly = 1) { repository.existsById(id) }
     }
@@ -337,7 +337,7 @@ class CustomerServiceTest {
             customerService.recipientValidate(transaction, sender)
         }
 
-        assertEquals("Customer [${recipientId}] não existe", error.message)
+        assertEquals("Customer [${recipientId}] não existe.", error.message)
         assertEquals("TO-003", error.errorCode)
         verify(exactly = 1) { repository.existsById(recipientId) }
     }
@@ -378,7 +378,7 @@ class CustomerServiceTest {
 
         val error = assertThrows<BadRequestException> { customerService.checkBalance(transaction, sender.saldo) }
 
-        assertEquals("Saldo insuficiente para efetuar esta operação", error.message)
+        assertEquals("Saldo insuficiente para efetuar esta operação.", error.message)
         assertEquals("TO-004", error.errorCode)
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,7 @@
 server.port=3001
 
 spring.jpa.hibernate.ddl-auto=update
+#spring.datasource.url=jdbc:mysql://localhost:3306/testepicpayAmbTeste?createDatabaseIfNotExist=true
 spring.datasource.url=jdbc:mysql://mysql57:3306/testepicpayAmbTeste?createDatabaseIfNotExist=true
 spring.datasource.username=root
 spring.datasource.password=Password123#@!


### PR DESCRIPTION
corrigido:
testes que estavam falhando por conta da mensagem esperada estar errada,

removido: 
anotação @cpf e @cnpj pois os mesmos estavam dando problema na inserção do campo. Após passar pela primeira notação, na segunda ele recussava e não permitia criar o usuario.